### PR TITLE
removed print method in events/views.py which caused 500 error due to

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -43,7 +43,6 @@ def submitted_event(request):
 def submit_event(request):
     form = EventForm()
     if request.method == 'POST':
-        print(request.POST, request.FILES)
         form = EventForm(request.POST, request.FILES)
 
         if form.is_valid():


### PR DESCRIPTION
very long string when a big image is uploaded.